### PR TITLE
🤖 Add authors and contributors to Practice Exercises

### DIFF
--- a/concepts/turbofish/links.json
+++ b/concepts/turbofish/links.json
@@ -6,5 +6,9 @@
   {
     "url": "https://matematikaadit.github.io/posts/rust-turbofish.html",
     "description": "where to put the turbofish"
+  },
+  {
+    "url": "https://turbo.fish/",
+    "description": "Endless swimming turbofish!"
   }
 ]

--- a/docs/maintaining.md
+++ b/docs/maintaining.md
@@ -42,3 +42,11 @@ Scripts expect GNU versions of tooling, so you may see unexpected results on mac
 [Here](https://github.com/exercism/rust/issues/1138) is one example.
 Windows users can also run tooling locally using [WSL](https://docs.microsoft.com/en-us/windows/wsl/).
 We recommend WSL 2 with the distribution of your choice.
+
+## Maintainer Tips and Tricks
+
+Exercism tracks follow a specification that has evolved over time.
+Maintainers often need to make ad-hoc migrations to files in this repository.
+If you find yourself scripting such ad-hoc changes, include the source of your script using markdown codeblocks in a commit message.
+
+See [this commit](https://github.com/exercism/rust/commit/45eb8cc113a733636212394dee946ceff5949cc3) for an example.

--- a/exercises/concept/assembly-line/.meta/config.json
+++ b/exercises/concept/assembly-line/.meta/config.json
@@ -1,14 +1,8 @@
 {
   "blurb": "Learn about numbers while working on an assembly line for cars.",
   "authors": [
-    {
-      "github_username": "LewisClement",
-      "exercism_username": "LewisClement"
-    },
-    {
-      "github_username": "efx",
-      "exercism_username": "efx"
-    }
+    "LewisClement",
+    "efx"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/csv-builder/.meta/config.json
+++ b/exercises/concept/csv-builder/.meta/config.json
@@ -1,18 +1,9 @@
 {
   "blurb": "TODO: add blurb for csv-builder exercise",
   "authors": [
-    {
-      "github_username": "gilescope",
-      "exercism_username": "gilescope"
-    },
-    {
-      "github_username": "coriolinus",
-      "exercism_username": "coriolinus"
-    },
-    {
-      "github_username": "efx",
-      "exercism_username": "efx"
-    }
+    "gilescope",
+    "coriolinus",
+    "efx"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/entry-api/.meta/config.json
+++ b/exercises/concept/entry-api/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for entry-api exercise",
   "authors": [
-    {
-      "github_username": "seanchen1991",
-      "exercism_username": "seanchen1991"
-    }
+    "seanchen1991"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/options/.meta/config.json
+++ b/exercises/concept/options/.meta/config.json
@@ -1,14 +1,8 @@
 {
   "blurb": "TODO: add blurb for options exercise",
   "authors": [
-    {
-      "github_username": "seanchen1991",
-      "exercism_username": "seanchen1991"
-    },
-    {
-      "github_username": "coriolinus",
-      "exercism_username": "coriolinus"
-    }
+    "seanchen1991",
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/semi-structured-logs/.meta/config.json
+++ b/exercises/concept/semi-structured-logs/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "Learn enums while building a logging utility.",
   "authors": [
-    {
-      "github_username": "efx",
-      "exercism_username": "efx"
-    }
+    "efx"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/structs/.meta/config.json
+++ b/exercises/concept/structs/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for structs exercise",
   "authors": [
-    {
-      "github_username": "seanchen1991",
-      "exercism_username": "seanchen1991"
-    }
+    "seanchen1991"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/tuples/.meta/config.json
+++ b/exercises/concept/tuples/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for tuples exercise",
   "authors": [
-    {
-      "github_username": "coriolinus",
-      "exercism_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/vec-macro/.meta/config.json
+++ b/exercises/concept/vec-macro/.meta/config.json
@@ -1,14 +1,8 @@
 {
   "blurb": "TODO: add blurb for vec-macro exercise",
   "authors": [
-    {
-      "github_username": "efx",
-      "exercism_username": "efx"
-    },
-    {
-      "github_username": "coriolinus",
-      "exercism_username": "coriolinus"
-    }
+    "efx",
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "sacherjj"
   ],
+  "contributors": [
+    "attilahorvath",
+    "ccouzens",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "Emerentius",
+    "ErikSchierboom",
+    "lutostag",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "authors": [
-    {
-      "github_username": "sacherjj"
-    }
+    "sacherjj"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "gregcline"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "ktomsic",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "thvdburgt",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Convert a long phrase to its acronym",
   "authors": [
-    {
-      "github_username": "gregcline"
-    }
+    "gregcline"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
   "authors": [
-    {
-      "github_username": "ktomsic"
-    }
+    "ktomsic"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -3,6 +3,14 @@
   "authors": [
     "ktomsic"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "ffflorian",
+    "petertseng"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -3,6 +3,24 @@
   "authors": [
     "jonasbb"
   ],
+  "contributors": [
+    "CGMossa",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "pedantic79",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
   "authors": [
-    {
-      "github_username": "jonasbb"
-    }
+    "jonasbb"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "taravancil",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Write a function to solve alphametics puzzles.",
   "authors": [
-    {
-      "github_username": "ijanos"
-    }
+    "ijanos"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "ijanos"
   ],
+  "contributors": [
+    "Baelyk",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "nikamirrr",
+    "omer-g",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -3,6 +3,33 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "ashleygwilliams",
+    "bobahop",
+    "chancancode",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "Dimkar3000",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "gris",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "pminten",
+    "quartsize",
+    "rofrol",
+    "stevejb71",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Determine if a number is an Armstrong number",
   "authors": [
-    {
-      "github_username": "shingtaklam1324"
-    }
+    "shingtaklam1324"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "shingtaklam1324"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "ocstl",
+    "petertseng",
+    "rofrol",
+    "sputnick1124",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -3,6 +3,25 @@
   "authors": [
     "nikhilshagri"
   ],
+  "contributors": [
+    "AvasDream",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "nikhilshagri",
+    "ocstl",
+    "rofrol",
+    "stringparser",
+    "vadimkerr",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
   "authors": [
-    {
-      "github_username": "nikhilshagri"
-    }
+    "nikhilshagri"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -3,6 +3,30 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kytrinyx",
+    "leoyvens",
+    "lutostag",
+    "mkantor",
+    "murlakatamenka",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "pminten",
+    "razielgn",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -3,6 +3,20 @@
   "authors": [
     "shybyte"
   ],
+  "contributors": [
+    "Cohen-Carlisle",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Implement a binary search algorithm.",
   "authors": [
-    {
-      "github_username": "shybyte"
-    }
+    "shybyte"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -3,6 +3,36 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "ashleygwilliams",
+    "austinlyons",
+    "cjmochrie",
+    "cmccandless",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "etrepum",
+    "f3rn0s",
+    "IanWhitney",
+    "kytrinyx",
+    "leoyvens",
+    "lewisclement",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "pminten",
+    "rofrol",
+    "rpottsoh",
+    "stefanv",
+    "stringparser",
+    "vvv",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -3,6 +3,18 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "Baelyk",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Score a bowling game",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -3,6 +3,23 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "britto",
+    "cmccandless",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "isgj",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -4,6 +4,7 @@
     "EduardoBautista"
   ],
   "contributors": [
+    "ekse",
     "alexschrod",
     "ashleygwilliams",
     "coriolinus",

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "alexschrod",
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "Jonah-Horowitz",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Implement a clock that handles times without dates.",
   "authors": [
-    {
-      "github_username": "sacherjj"
-    }
+    "sacherjj"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "sacherjj"
   ],
+  "contributors": [
+    "attilahorvath",
+    "coriolinus",
+    "cwhakes",
+    "danieljl",
+    "eddyp",
+    "efx",
+    "ErikSchierboom",
+    "felix91gr",
+    "kunaltyagi",
+    "lutostag",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "shaaraddalvi",
+    "stringparser",
+    "tmccombs",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [
-    {
-      "github_username": "jgilray"
-    }
+    "jgilray"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -3,6 +3,20 @@
   "authors": [
     "jgilray"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Implement the classic method for composing secret messages called a square code.",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "Baelyk",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "f3rn0s",
+    "lutostag",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "etrepum",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Create a custom set type.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/decimal/.meta/config.json
+++ b/exercises/practice/decimal/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "Implement a Decimal type",
+  "source": "Peter Goodspeed-Niklaus",
   "authors": [
     {
       "github_username": "coriolinus"

--- a/exercises/practice/decimal/.meta/config.json
+++ b/exercises/practice/decimal/.meta/config.json
@@ -2,9 +2,7 @@
   "blurb": "Implement a Decimal type",
   "source": "Peter Goodspeed-Niklaus",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/decimal/.meta/config.json
+++ b/exercises/practice/decimal/.meta/config.json
@@ -4,6 +4,19 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "Baelyk",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/decimal/.meta/metadata.yml
+++ b/exercises/practice/decimal/.meta/metadata.yml
@@ -1,3 +1,0 @@
----
-blurb: "Implement a Decimal type"
-source: "Peter Goodspeed-Niklaus"

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
   "authors": [
-    {
-      "github_username": "Menkir"
-    }
+    "Menkir"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -3,6 +3,19 @@
   "authors": [
     "Menkir"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -3,6 +3,27 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kytrinyx",
+    "leoyvens",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "TheDarkula",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -3,6 +3,20 @@
   "authors": [
     "hekrause"
   ],
+  "contributors": [
+    "Baelyk",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "LeBlue",
+    "lutostag",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Diffie-Hellman key exchange.",
   "authors": [
-    {
-      "github_username": "hekrause"
-    }
+    "hekrause"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -3,6 +3,29 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "AndrewKvalheim",
+    "ashleygwilliams",
+    "ClashTheBunny",
+    "cmccandless",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "etrepum",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Make a chain of dominoes.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/dot-dsl/.meta/config.json
+++ b/exercises/practice/dot-dsl/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Write a Domain Specific Language similar to the Graphviz dot language",
   "authors": [
-    {
-      "github_username": "ZapAnton"
-    }
+    "ZapAnton"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/dot-dsl/.meta/config.json
+++ b/exercises/practice/dot-dsl/.meta/config.json
@@ -3,6 +3,18 @@
   "authors": [
     "ZapAnton"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "TheDarkula",
+    "TomPradat"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/doubly-linked-list/.meta/config.json
+++ b/exercises/practice/doubly-linked-list/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "linked-list",
   "authors": [
-    {
-      "github_username": "Emerentius"
-    }
+    "Emerentius"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/doubly-linked-list/.meta/config.json
+++ b/exercises/practice/doubly-linked-list/.meta/config.json
@@ -3,6 +3,14 @@
   "authors": [
     "Emerentius"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "petertseng",
+    "rofrol"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/doubly-linked-list/.meta/metadata.yml
+++ b/exercises/practice/doubly-linked-list/.meta/metadata.yml
@@ -1,4 +1,0 @@
----
-blurb: "linked-list"
-source: ""
-source_url: ""

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -3,6 +3,28 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kotp",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "tushartyagi",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/fizzy/.meta/config.json
+++ b/exercises/practice/fizzy/.meta/config.json
@@ -1,5 +1,7 @@
 {
   "blurb": "Implement FizzBuzz using advanced generics",
+  "source": "Peter Goodspeed-Niklaus",
+  "source_url": "https://github.com/coriolinus/fizzy",
   "authors": [
     {
       "github_username": "coriolinus"

--- a/exercises/practice/fizzy/.meta/config.json
+++ b/exercises/practice/fizzy/.meta/config.json
@@ -5,6 +5,16 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "insideoutclub",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/fizzy/.meta/config.json
+++ b/exercises/practice/fizzy/.meta/config.json
@@ -3,9 +3,7 @@
   "source": "Peter Goodspeed-Niklaus",
   "source_url": "https://github.com/coriolinus/fizzy",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/fizzy/.meta/metadata.yml
+++ b/exercises/practice/fizzy/.meta/metadata.yml
@@ -1,4 +1,0 @@
----
-blurb: "Implement FizzBuzz using advanced generics"
-source: "Peter Goodspeed-Niklaus"
-source_url: "https://github.com/coriolinus/fizzy"

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Implement an evaluator for a very simple subset of Forth",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -3,6 +3,31 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "bobahop",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "gefjon",
+    "gsauthof",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "N-Parsons",
+    "nfiles",
+    "PaulDance",
+    "petertseng",
+    "pminten",
+    "robkeim",
+    "rofrol",
+    "stevejb71",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -3,6 +3,31 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "andy5995",
+    "ashleygwilliams",
+    "cbzehner",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "houhoulis",
+    "IanWhitney",
+    "janczer",
+    "leoyvens",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "NieDzejkob",
+    "ocstl",
+    "petertseng",
+    "rofrol",
+    "sacherjj",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -3,6 +3,29 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "ffflorian",
+    "IanWhitney",
+    "kytrinyx",
+    "lpil",
+    "lutostag",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "pminten",
+    "rofrol",
+    "stevejb71",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -3,6 +3,23 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "krodyrobi",
+    "lutostag",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "TheDarkula",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
   "authors": [
-    {
-      "github_username": "ZapAnton"
-    }
+    "ZapAnton"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -3,6 +3,18 @@
   "authors": [
     "ZapAnton"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "k33nice",
+    "lutostag",
+    "petertseng",
+    "rofrol",
+    "stringparser"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -3,6 +3,27 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "AvasDream",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "Henning-K",
+    "IanWhitney",
+    "jonasbb",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -3,6 +3,28 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "dvoytik",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "hydhknn",
+    "IanWhitney",
+    "ijanos",
+    "kytrinyx",
+    "lutostag",
+    "nfiles",
+    "petertseng",
+    "regnerjr",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -3,6 +3,25 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -3,6 +3,12 @@
   "authors": [
     "Br1ght0ne"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Manage a player's High Score list",
   "authors": [
-    {
-      "github_username": "Br1ght0ne"
-    }
+    "Br1ght0ne"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Check if a given string is a valid ISBN-10 number.",
   "authors": [
-    {
-      "github_username": "ktomsic"
-    }
+    "ktomsic"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "ktomsic"
   ],
+  "contributors": [
+    "Baelyk",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "nathanielknight",
+    "petertseng",
+    "rofrol",
+    "rpottsoh",
+    "stringparser",
+    "Teo-ShaoWei",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -3,6 +3,18 @@
   "authors": [
     "hekrause"
   ],
+  "contributors": [
+    "AvasDream",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Determine if a word or phrase is an isogram.",
   "authors": [
-    {
-      "github_username": "hekrause"
-    }
+    "hekrause"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -3,6 +3,21 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a year, report if it is a leap year.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -3,6 +3,36 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "andy5995",
+    "ashleygwilliams",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "darnuria",
+    "EduardoBautista",
+    "efx",
+    "Emerentius",
+    "ErikSchierboom",
+    "hunger",
+    "IanWhitney",
+    "JIghtuse",
+    "jonasbn",
+    "kytrinyx",
+    "leoyvens",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "pminten",
+    "rofrol",
+    "sshine",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/luhn-from/.meta/config.json
+++ b/exercises/practice/luhn-from/.meta/config.json
@@ -2,9 +2,7 @@
   "blurb": "Luhn: Using the From Trait",
   "source": "The Rust track maintainers, based on the original Luhn exercise",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/luhn-from/.meta/config.json
+++ b/exercises/practice/luhn-from/.meta/config.json
@@ -4,6 +4,22 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "Insti",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/luhn-from/.meta/config.json
+++ b/exercises/practice/luhn-from/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "Luhn: Using the From Trait",
+  "source": "The Rust track maintainers, based on the original Luhn exercise",
   "authors": [
     {
       "github_username": "IanWhitney"

--- a/exercises/practice/luhn-from/.meta/metadata.yml
+++ b/exercises/practice/luhn-from/.meta/metadata.yml
@@ -1,3 +1,0 @@
----
-blurb: "Luhn: Using the From Trait"
-source: "The Rust track maintainers, based on the original Luhn exercise"

--- a/exercises/practice/luhn-trait/.meta/config.json
+++ b/exercises/practice/luhn-trait/.meta/config.json
@@ -2,9 +2,7 @@
   "blurb": "Luhn: Using a Custom Trait",
   "source": "The Rust track maintainers, based on the original Luhn exercise",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/luhn-trait/.meta/config.json
+++ b/exercises/practice/luhn-trait/.meta/config.json
@@ -4,6 +4,23 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "Insti",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/luhn-trait/.meta/config.json
+++ b/exercises/practice/luhn-trait/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "Luhn: Using a Custom Trait",
+  "source": "The Rust track maintainers, based on the original Luhn exercise",
   "authors": [
     {
       "github_username": "IanWhitney"

--- a/exercises/practice/luhn-trait/.meta/metadata.yml
+++ b/exercises/practice/luhn-trait/.meta/metadata.yml
@@ -1,3 +1,0 @@
----
-blurb: "Luhn: Using a Custom Trait"
-source: "The Rust track maintainers, based on the original Luhn exercise"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -3,6 +3,27 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "AvasDream",
+    "bitfield",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "gibfahn",
+    "idealhack",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stkent",
+    "stringparser",
+    "workingjubilee",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/macros/.meta/config.json
+++ b/exercises/practice/macros/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "Implement a macro using macros-by-example",
+  "source": "Peter Goodspeed-Niklaus",
   "authors": [
     {
       "github_username": "coriolinus"

--- a/exercises/practice/macros/.meta/config.json
+++ b/exercises/practice/macros/.meta/config.json
@@ -4,6 +4,23 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "bantic",
+    "cwhakes",
+    "DarthStrom",
+    "efx",
+    "Emerentius",
+    "ErikSchierboom",
+    "lutostag",
+    "pedantic79",
+    "petertseng",
+    "rofrol",
+    "ssomers",
+    "stringparser",
+    "tjade273",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/macros/.meta/config.json
+++ b/exercises/practice/macros/.meta/config.json
@@ -2,9 +2,7 @@
   "blurb": "Implement a macro using macros-by-example",
   "source": "Peter Goodspeed-Niklaus",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/macros/.meta/metadata.yml
+++ b/exercises/practice/macros/.meta/metadata.yml
@@ -1,3 +1,0 @@
----
-blurb: "Implement a macro using macros-by-example"
-source: "Peter Goodspeed-Niklaus"

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Make sure the brackets and braces all match.",
   "authors": [
-    {
-      "github_username": "petertseng"
-    }
+    "petertseng"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -3,6 +3,25 @@
   "authors": [
     "petertseng"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "Emerentius",
+    "ErikSchierboom",
+    "IanWhitney",
+    "ironhaven",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "omer-g",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "ffflorian",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "workingjubilee",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Add the numbers to a minesweeper board",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -3,6 +3,23 @@
   "authors": [
     "sacherjj"
   ],
+  "contributors": [
+    "attilahorvath",
+    "cbzehner",
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "efx",
+    "ErikSchierboom",
+    "imbolc",
+    "lutostag",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a number n, determine what the nth prime is.",
   "authors": [
-    {
-      "github_username": "sacherjj"
-    }
+    "sacherjj"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/nucleotide-codons/.meta/config.json
+++ b/exercises/practice/nucleotide-codons/.meta/config.json
@@ -3,6 +3,25 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/nucleotide-codons/.meta/config.json
+++ b/exercises/practice/nucleotide-codons/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Write a function that returns the name of an amino acid a particular codon, possibly using shorthand, encodes for.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -3,6 +3,28 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "ashleygwilliams",
+    "cmcaine",
+    "coriolinus",
+    "cwhakes",
+    "Dysp",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "pminten",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -3,6 +3,23 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/paasio/.meta/config.json
+++ b/exercises/practice/paasio/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Report network IO statistics",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/paasio/.meta/config.json
+++ b/exercises/practice/paasio/.meta/config.json
@@ -3,6 +3,19 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "ccouzens",
+    "ClashTheBunny",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "petertseng",
+    "rofrol",
+    "shenek",
+    "stringparser",
+    "TheDarkula",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Detect palindrome products in a given range.",
   "authors": [
-    {
-      "github_username": "Menkir"
-    }
+    "Menkir"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -3,6 +3,19 @@
   "authors": [
     "Menkir"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "DmitrySamoylov",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Determine if a sentence is a pangram.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -3,6 +3,24 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "AvasDream",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/parallel-letter-frequency/.meta/config.json
+++ b/exercises/practice/parallel-letter-frequency/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Count the frequency of letters in texts using parallel computation.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/parallel-letter-frequency/.meta/config.json
+++ b/exercises/practice/parallel-letter-frequency/.meta/config.json
@@ -3,6 +3,30 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "ashleygwilliams",
+    "ccouzens",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "etrepum",
+    "glennpratt",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "sjwarner-bp",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -3,6 +3,21 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "hekrause",
+    "lutostag",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
   "authors": [
-    {
-      "github_username": "matbesancon"
-    }
+    "matbesancon"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "matbesancon"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "efx",
+    "elbaro",
+    "ErikSchierboom",
+    "lutostag",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -3,6 +3,31 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "ashleygwilliams",
+    "coriolinus",
+    "cscorley",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "pminten",
+    "rofrol",
+    "Stargator",
+    "stevejb71",
+    "stringparser",
+    "vinmaster",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "sacherjj"
   ],
+  "contributors": [
+    "attilahorvath",
+    "Baelyk",
+    "ccouzens",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Implement a program that translates from English to Pig Latin",
   "authors": [
-    {
-      "github_username": "sacherjj"
-    }
+    "sacherjj"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "Baelyk",
+    "CGMossa",
+    "cwhakes",
+    "efx",
+    "elektronaut0815",
+    "ErikSchierboom",
+    "lutostag",
+    "nfiles",
+    "PaulDance",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Pick the best hand(s) from a list of poker hands.",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Compute the prime factors of a given natural number.",
   "authors": [
-    {
-      "github_username": "sacherjj"
-    }
+    "sacherjj"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "sacherjj"
   ],
+  "contributors": [
+    "attilahorvath",
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "nathanielknight",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Translate RNA sequences into proteins.",
   "authors": [
-    {
-      "github_username": "petertseng"
-    }
+    "petertseng"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -3,6 +3,24 @@
   "authors": [
     "petertseng"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "go717franciswang",
+    "IanWhitney",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nertpinx",
+    "nfiles",
+    "piepero",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "sacherjj"
   ],
+  "contributors": [
+    "attilahorvath",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "leoyvens",
+    "lutostag",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
   "authors": [
-    {
-      "github_username": "sacherjj"
-    }
+    "sacherjj"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
   "authors": [
-    {
-      "github_username": "sacherjj"
-    }
+    "sacherjj"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -3,6 +3,25 @@
   "authors": [
     "sacherjj"
   ],
+  "contributors": [
+    "attilahorvath",
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "efx",
+    "elbaro",
+    "ErikSchierboom",
+    "fudanchii",
+    "lutostag",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "TheBestJohn",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -3,6 +3,23 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Implement encoding and decoding for the rail fence cipher.",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -3,6 +3,15 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -3,6 +3,28 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kytrinyx",
+    "leoyvens",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stevejb71",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "petertseng"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "jku",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Implement a basic reactive system.",
   "authors": [
-    {
-      "github_username": "petertseng"
-    }
+    "petertseng"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Count the rectangles in an ASCII diagram.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Reverse a string",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -3,6 +3,23 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "cbzehner",
+    "ccouzens",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "hunger",
+    "lutostag",
+    "ocstl",
+    "petertseng",
+    "rofrol",
+    "rrredface",
+    "stringparser",
+    "TheDarkula",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -3,6 +3,33 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "AndrewKvalheim",
+    "ashleygwilliams",
+    "benreyn",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "etrepum",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "pminten",
+    "rofrol",
+    "rpottsoh",
+    "samcday",
+    "shingtaklam1324",
+    "stringparser",
+    "TheDarkula",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -3,6 +3,32 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "ashleygwilliams",
+    "ClashTheBunny",
+    "cmcaine",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ekse",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "pminten",
+    "razielgn",
+    "rofrol",
+    "spazm",
+    "stringparser",
+    "workingjubilee",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Manage robot factory settings.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -3,6 +3,21 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Write a robot simulator.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -3,6 +3,24 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "LogoiLab"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
   "authors": [
-    {
-      "github_username": "LogoiLab"
-    }
+    "LogoiLab"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Implement run-length encoding and decoding.",
   "authors": [
-    {
-      "github_username": "divagant-martian"
-    }
+    "divagant-martian"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -3,6 +3,22 @@
   "authors": [
     "divagant-martian"
   ],
+  "contributors": [
+    "attilahorvath",
+    "AvasDream",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "hekrause"
   ],
+  "contributors": [
+    "bitfield",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "Emerentius",
+    "ErikSchierboom",
+    "michalfita",
+    "mtodor",
+    "murlakatamenka",
+    "petertseng",
+    "RiderSargent",
+    "rofrol",
+    "scarvalhojr",
+    "stringparser",
+    "workingjubilee",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Detect saddle points in a matrix.",
   "authors": [
-    {
-      "github_username": "hekrause"
-    }
+    "hekrause"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
   "authors": [
-    {
-      "github_username": "sacherjj"
-    }
+    "sacherjj"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -3,6 +3,24 @@
   "authors": [
     "sacherjj"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "attilahorvath",
+    "AvasDream",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "f3rn0s",
+    "lutostag",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -3,6 +3,16 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "petertseng",
+    "r4f4",
+    "rofrol",
+    "stringparser",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "AvasDream",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "juleskers",
+    "kotp",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a word, compute the Scrabble score for that word.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
   "authors": [
-    {
-      "github_username": "kedeggel"
-    }
+    "kedeggel"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -3,6 +3,19 @@
   "authors": [
     "kedeggel"
   ],
+  "contributors": [
+    "Baelyk",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -3,6 +3,23 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
   "authors": [
-    {
-      "github_username": "miken500"
-    }
+    "miken500"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -3,6 +3,21 @@
   "authors": [
     "miken500"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "chivalry",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "petertseng",
+    "rofrol",
+    "rpottsoh",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Write a simple linked list implementation that uses Elements and a List",
   "authors": [
-    {
-      "github_username": "kedeggel"
-    }
+    "kedeggel"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -3,6 +3,21 @@
   "authors": [
     "kedeggel"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "ocstl",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "tejasbubane",
+    "treble37",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "bobahop",
+    "coriolinus",
+    "cwhakes",
+    "durka",
+    "eddyp",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "joshgoebel",
+    "lutostag",
+    "nfiles",
+    "ocstl",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -3,6 +3,18 @@
   "authors": [
     "Menkir"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "lutostag",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": " Given the size, return a square matrix of numbers in spiral order.",
   "authors": [
-    {
-      "github_username": "Menkir"
-    }
+    "Menkir"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -3,6 +3,25 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Write a function to determine if a list is a sublist of another list.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -3,6 +3,25 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "efx",
+    "ErikSchierboom",
+    "GoneUp",
+    "hekrause",
+    "leoyvens",
+    "lutostag",
+    "mkantor",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "sshine",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Tally the results of a small football competition.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -3,6 +3,29 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "ashleygwilliams",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "etrepum",
+    "IanWhitney",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "samcday",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -3,6 +3,26 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "CGMossa",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "jalovatt",
+    "lpil",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -3,6 +3,20 @@
   "authors": [
     "ktomsic"
   ],
+  "contributors": [
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "iHiD",
+    "lutostag",
+    "petertseng",
+    "rofrol",
+    "Smarticles101",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
   "authors": [
-    {
-      "github_username": "ktomsic"
-    }
+    "ktomsic"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -3,6 +3,21 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "ffflorian",
+    "hilary",
+    "joshgoebel",
+    "lutostag",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "uzilan",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -3,6 +3,24 @@
   "authors": [
     "jonasbb"
   ],
+  "contributors": [
+    "AndrewKvalheim",
+    "ashleygwilliams",
+    "coriolinus",
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "quartsize",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Implement variable length quantity encoding and decoding.",
   "authors": [
-    {
-      "github_username": "jonasbb"
-    }
+    "jonasbb"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "authors": [
-    {
-      "github_username": "EduardoBautista"
-    }
+    "EduardoBautista"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -3,6 +3,32 @@
   "authors": [
     "EduardoBautista"
   ],
+  "contributors": [
+    "andrewclarkson",
+    "ashleygwilliams",
+    "AvasDream",
+    "ClashTheBunny",
+    "coriolinus",
+    "cwhakes",
+    "EduardoBautista",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "ijanos",
+    "jonmcalder",
+    "kytrinyx",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "pminten",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "yawpitch",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -3,6 +3,25 @@
   "authors": [
     "IanWhitney"
   ],
+  "contributors": [
+    "ashleygwilliams",
+    "ccouzens",
+    "coriolinus",
+    "cwhakes",
+    "eddyp",
+    "efx",
+    "ErikSchierboom",
+    "IanWhitney",
+    "lutostag",
+    "mkantor",
+    "navossoc",
+    "nfiles",
+    "petertseng",
+    "rofrol",
+    "stringparser",
+    "xakon",
+    "ZapAnton"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,9 +1,7 @@
 {
   "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
   "authors": [
-    {
-      "github_username": "IanWhitney"
-    }
+    "IanWhitney"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/xorcism/.meta/config.json
+++ b/exercises/practice/xorcism/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "Implement zero-copy streaming adaptors",
+  "source": "Peter Goodspeed-Niklaus",
   "authors": [
     {
       "github_username": "coriolinus"

--- a/exercises/practice/xorcism/.meta/config.json
+++ b/exercises/practice/xorcism/.meta/config.json
@@ -2,9 +2,7 @@
   "blurb": "Implement zero-copy streaming adaptors",
   "source": "Peter Goodspeed-Niklaus",
   "authors": [
-    {
-      "github_username": "coriolinus"
-    }
+    "coriolinus"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/xorcism/.meta/config.json
+++ b/exercises/practice/xorcism/.meta/config.json
@@ -4,6 +4,13 @@
   "authors": [
     "coriolinus"
   ],
+  "contributors": [
+    "cwhakes",
+    "efx",
+    "ErikSchierboom",
+    "petertseng",
+    "snoyberg"
+  ],
   "files": {
     "solution": [
       "src/lib.rs"

--- a/exercises/practice/xorcism/.meta/metadata.yml
+++ b/exercises/practice/xorcism/.meta/metadata.yml
@@ -1,3 +1,0 @@
----
-blurb: "Implement zero-copy streaming adaptors"
-source: "Peter Goodspeed-Niklaus"


### PR DESCRIPTION
With v3, we've introduced the idea of exercise authors and contributors. This information is stored in the exercise's `.meta/config.json` file (see [the docs](https://github.com/exercism/docs/blob/main/anatomy/tracks/practice-exercises.md#file-metaconfigjson)).

Concept Exercises, which are all new, have all defined their authors and contributors. Practice Exercises though are missing this information. In this PR, we attempt to populate the authors and contributors of Practice Exercises based on their commit history.

## Algorithm

We start out by looking at the current Practice Exercises. For each Practice Exercise, we'll look at the commit history of its files to see which commits did something with that Practice Exercise. How renames are handled is discussed in the "Renames" section later in this document. 

Each commit that we can link to a Practice Exercise will be used to determine authorship/contributorship. Here is how we assign authorship/contributorship:

### Authors

1. Find the Git commit author of the oldest commit linked to that Practice Exercise. As there can only be one oldest commit, we only have one author
2. Find the GitHub username for the Git commit author of that commit
3. Add the GitHub username of the Git commit author to the `authors` key in the `.meta/config.json` file

### Contributors

1. Find the Git commit authors of all but the oldest commit linked to that Practice Exercise. If there is only one commit, there won't be any contributors.
1. Exclude the Git commit author of the oldest commit from the list of Git commit authors (an author is _not_ also a contributor) 
2. Find the GitHub usernames for the Git commit authors of those commits
3. Add the GitHub usernames of the Git commit authors to the `contributor` key in the `.meta/config.json` file

We're using the GitHub GraphQL API to find the username of a commit author. In some cases though, a username cannot be found for a commit (e.g. due to the user account no longer existing), in which case we'll skip the commit. 

## Renames

There is a select number of Practice Exercises that might have been renamed at some point. You can ask Git to "follow" a file over its renames using `git log --follow <file>`, which will also return commits made before renames. Unfortunately, Git does not store renames, it just stores the contents of the renamed files and tries to guess if a file was renamed by looking at its contents. This _can_ (and will) lead to false positives, where Git will think a file has been renamed whereas it hasn't. As we don't want to have incorrect authors/contributors for exercises, we're ignoring renames. The only exception to this are known exercise renames:

- `bracket-push` was renamed to `matching-brackets`
- `retree` was renamed to `satellite`
- `resistor-colors` was renamed to `resistor-color-duo`
- `kindergarden-garden` was renamed to `kindergarten-garden`

If you know of a rename of a Practice Exercise, please check to see if its authors and contributors are correctly set.

## Exclusions

There are some commits that we skip over, which thus don't influence the authors/contributors list:

- Commits authored by `dependabot[bot]`, `dependabot-preview[bot]` or `github-actions[bot]`
- Bulk update PRs made by `ErikSchierboom` or `kytrinx` to update the track

## Maintainer TODO list

These are the things you, the maintainers, should do:

- Check the authors and contributors, adding/removing users where the data is missing or incorrect
- Double-check any renamed Practice Exercises
- Check for Practice Exercises with missing authors, which is most likely due to the author not being on GitHub anymore 
- Add additional authors if you know that a Practice Exercise has actually been created by more than one author 

If you find something needs updating, just push a new commit to this PR.

## Tracking

https://github.com/exercism/v3-launch/issues/24
